### PR TITLE
DRUPSIBLE-105 #comment Remove workaround now Vagrant 1.8 is out (and …

### DIFF
--- a/Vagrantfile.default
+++ b/Vagrantfile.default
@@ -11,23 +11,13 @@ require 'yaml'
 VAGRANTFILE_API_VERSION = "2"
 
 # Minimum Vagrant version required
-Vagrant.require_version ">= 1.7.2"
+Vagrant.require_version ">= 1.8.1"
 
 # Use rbconfig to determine if we're on a windows host or not.
 require 'rbconfig'
 is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin|msys|bccwin|wince|emc/)
 if is_windows
   install_windows_param = 'is_windows'
-# Due to this bug https://github.com/mitchellh/vagrant/issues/6026,
-# we need this workaround.
-  if ARGV[0].eql?'up' or ARGV[0].eql?'provision'
-    retcode = system("set | grep VAGRANT_DETECTED_OS")
-    if !retcode
-      puts "Due to this open bug https://github.com/mitchellh/vagrant/issues/6026,"
-      puts "please run: export VAGRANT_DETECTED_OS=cygwin; vagrant up"
-      exit
-    end
-  end
 end
 
 # Install required plugins if not present.


### PR DESCRIPTION
…enforce the new version)